### PR TITLE
Fix warnings in deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,10 +1,10 @@
 {:paths ["src"]
  :deps {koan-engine/koan-engine {:mvn/version "0.2.5"}
-        compojure  {:mvn/version "1.6.2"}
-        ring {:mvn/version "1.8.2"}
+        compojure/compojure  {:mvn/version "1.6.2"}
+        ring/ring {:mvn/version "1.8.2"}
         ring/ring-json  {:mvn/version "0.5.0"}
-        clj-http  {:mvn/version "3.10.3"}
-        cheshire {:mvn/version "5.10.0"}}
+        clj-http/clj-http  {:mvn/version "3.10.3"}
+        cheshire/cheshire {:mvn/version "5.10.0"}}
  :aliases {:repl {:extra-deps {org.clojure/clojure {:mvn/version "1.10.1"}
                                cider/cider-nrepl {:mvn/version "0.25.3"}}
                   :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}}}


### PR DESCRIPTION
Fixes
``` shell
DEPRECATED: Libs must be qualified, change compojure => compojure/compojure (deps.edn)
DEPRECATED: Libs must be qualified, change ring => ring/ring (deps.edn)
DEPRECATED: Libs must be qualified, change clj-http => clj-http/clj-http (deps.edn)
DEPRECATED: Libs must be qualified, change cheshire => cheshire/cheshire (deps.edn)
```